### PR TITLE
Fix leftover displays

### DIFF
--- a/src/main/java/uk/antiperson/stackmob/StackMob.java
+++ b/src/main/java/uk/antiperson/stackmob/StackMob.java
@@ -10,6 +10,7 @@ import uk.antiperson.stackmob.commands.Commands;
 import uk.antiperson.stackmob.config.EntityTranslation;
 import uk.antiperson.stackmob.config.MainConfig;
 import uk.antiperson.stackmob.entity.EntityManager;
+import uk.antiperson.stackmob.entity.StackEntity;
 import uk.antiperson.stackmob.entity.tags.DisplayTagListeners;
 import uk.antiperson.stackmob.entity.traits.TraitManager;
 import uk.antiperson.stackmob.hook.HookManager;
@@ -102,7 +103,7 @@ public class StackMob extends JavaPlugin {
         commands.registerSubCommands();
         int stackInterval = getMainConfig().getConfig().getStackInterval();
         getScheduler().runGlobalTaskTimer(new MergeTask(this), 20, stackInterval);
-        if (getMainConfig().getConfig().isUseArmorStand()) {
+        if (getMainConfig().getConfig().isUseArmorStand() && getMainConfig().getConfig().getTagMode() == StackEntity.TagMode.NEARBY) {
             getServer().getPluginManager().registerEvents(new DisplayTagListeners(this), this);
         }
         getLogger().info("Detected server version " + Utilities.getMinecraftVersion());

--- a/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
@@ -583,7 +583,7 @@ public class StackEntity {
             LivingEntity entity = getEntity();
             int threshold = getEntityConfig().getTagThreshold();
             if (getSize() <= threshold) {
-                if (getEntityConfig().isUseArmorStand()) {
+                if (getEntityConfig().isUseArmorStand() && getEntityConfig().getTagMode() == TagMode.NEARBY) {
                     if (getDisplayTag().exists()) {
                         getDisplayTag().remove();
                     }
@@ -597,7 +597,7 @@ public class StackEntity {
             format = format.replace("%type%", getEntityName());
             format = format.replace("%size%", getSize() + "");
             displayName = Utilities.createComponent(format);
-            if (getEntityConfig().isUseArmorStand()) {
+            if (getEntityConfig().isUseArmorStand() && getEntityConfig().getTagMode() == TagMode.NEARBY) {
                 if (!getDisplayTag().exists()) {
                     getDisplayTag().spawn();
                 }


### PR DESCRIPTION
During the process of moving to text displays, the NEARBY tag mode was removed resulting in the displays being spawned no matter what.

Simply setting the `display-name.nearby.armorstand.enabled` config setting to false was a workaround for this bug, but changing that shouldn't be required.